### PR TITLE
Frmting

### DIFF
--- a/main_draft.py
+++ b/main_draft.py
@@ -6,62 +6,66 @@ import statistics as stat
 from ete3 import Tree
 from typing import List
 
-##Opening Tree and ID Files
-def open_tree_file(id, td):
-    id_dir = str(id)
-    tree_dir = str(td)
 
-    tax_ids_handler = open(id_dir)
-    dict = {}
+# Opening Tree and ID Files
+def open_tree_file(taxa_table_file: str, newick_file: str):
+    """
+    There is some sort of taxonomic lineage-based filtering
+    :param taxa_table_file:
+    :param newick_file:
+    :return:
+    """
+    taxa_table_file = str(taxa_table_file)
+    newick_file = str(newick_file)
+
+    tax_ids_handler = open(taxa_table_file)
+    tree_num_to_lineage_map = {}
     for line in tax_ids_handler:
-        fields = line.split('\t')
-        tax = fields[2].rstrip()
-        tax = tax.split('; ')
-        dict[fields[0]] = tax
+        tree_id, desc, lineage = line.split('\t')
+        tax = lineage.rstrip().split('; ')
+        tree_num_to_lineage_map[tree_id] = tax
     tax_ids_handler.close()
 
-    tree_handler = open(tree_dir)
+    tree_handler = open(newick_file)
     tree_contents = tree_handler.read()
     t = Tree(tree_contents)
     tree_handler.close()
 
-
-    ##Mapping lineages to leaf nodes
+    # Mapping lineages to leaf nodes
     for node in t.get_leaves():
         num = node.name
-        node.add_features(lineage=dict[str(num)])
+        node.add_features(lineage=tree_num_to_lineage_map[str(num)])
 
-
-    #Add cellular organisms tax group to lineages w/o it
+    # Add cellular organisms tax group to lineages w/o it
     for node in t.traverse():
-        if node.is_leaf() and not 'cellular organisms' in node.lineage:
+        if node.is_leaf() and 'cellular organisms' not in node.lineage:
             new_lin = ['cellular organisms'] + node.lineage
             node.add_features(lineage=new_lin)
-            #print(node.lineage)
+            # print(node.lineage)
     return t
 
 
-#Functions to find avg dist from leaves to a nodes parent (for calculation of RED)
+# Functions to find avg dist from leaves to a nodes parent (for calculation of RED)
 class Dist(object):
     @staticmethod
     def avg_dist_to_this_nodes_parent(node):
-        '''
+        """
         get avg distance from leaves to this node's parent
-        '''
+        """
         return Dist.avg(Dist.get_list_distances_of_this_nodes_leaves_to_nodes_parent(node))
 
     @staticmethod
     def avg(l: List[float]):
-        '''
+        """
         averages list of numbers
-        '''
+        """
         return sum(l)/len(l)
 
     @staticmethod
     def get_list_distances_of_this_nodes_leaves_to_nodes_parent(node):
-        '''
+        """
         from this node, get list of distances from child leaves
-        '''
+        """
         l = []
         parent_node = node.up
         for n in node.get_leaves():
@@ -69,14 +73,14 @@ class Dist(object):
         return l
 
 
-##Functions for getting LCA from leaf node info
+# Functions for getting LCA from leaf node info
 class LCA(object):
 
     @staticmethod
     def get_lca_lineage(node):
-        '''
-        main function that returns lineage bassed on 'passed' leaf nodes
-        '''
+        """
+        main function that returns lineage based on 'passed' leaf nodes
+        """
         return LCA.get_commons_from_mult_lists(LCA.get_leaf_linages_passed(node))
 
     @staticmethod
@@ -84,35 +88,35 @@ class LCA(object):
         for node in t.traverse():
             node.add_features(_pass=True)
         for leaf in t:
-            if ('r1leaves' in keyword_parameters):
+            if 'r1leaves' in keyword_parameters:
                 if keyword_parameters['r1leaves']:
                     if LCA.rank_assessment(leaf.lineage) == 1:
                         leaf.add_features(_pass=False)
-            if ('r2leaves' in keyword_parameters):
+            if 'r2leaves' in keyword_parameters:
                 if LCA.rank_assessment(leaf.lineage) == 2:
                     if keyword_parameters['r2leaves']:
                         leaf.add_features(_pass=False)
-            if ('metagenome' in keyword_parameters):
+            if 'metagenome' in keyword_parameters:
                 if leaf in LCA.list_leaves_at_rank(t, 'metagenome', keyword_parameters['metagenome']):
                     leaf.add_features(_pass=False)
-            if ('environmental_samples' in keyword_parameters):
+            if 'environmental_samples' in keyword_parameters:
                 if leaf in LCA.list_leaves_at_rank(t, 'environmental samples', keyword_parameters['environmental_samples']):
                     leaf.add_features(_pass=False)
-            if ('unclassified' in keyword_parameters):
+            if 'unclassified' in keyword_parameters:
                 if leaf in LCA.list_leaves_at_rank(t, 'unclassified', keyword_parameters['unclassified']):
                     leaf.add_features(_pass=False)
-            if ('candidatus' in keyword_parameters):
+            if 'candidatus' in keyword_parameters:
                 if leaf in LCA.list_leaves_at_rank(t, 'Candidatus', keyword_parameters['candidatus']):
                     leaf.add_features(_pass=False)
-            if ('miscellaneous' in keyword_parameters):
+            if 'miscellaneous' in keyword_parameters:
                 if leaf in LCA.list_leaves_at_rank(t, 'miscellaneous', keyword_parameters['miscellaneous']):
                     leaf.add_features(_pass=False)
 
     @staticmethod
     def get_leaf_linages_passed(node):
-        '''
+        """
         appends list of leaves that are 'passed'
-        '''
+        """
         l = []
         for n in node.get_leaves():
             if n._pass:
@@ -121,11 +125,11 @@ class LCA(object):
 
     @staticmethod
     def list_leaves_at_rank(t, cls, rank):
-        '''
+        """
         given tree and rank level you want to assess, returns a list of node names of a certain class
         (i.e. 'environmental samples') that is within that rank level and above
         e.g. t, cls='metagenome', rank=5 --> returns list of leaves at rank 1-5 that have metagenome within its lineage
-        '''
+        """
         l = []
         for node in t.get_leaves():
             if LCA.rank_assessment(node.lineage) <= rank:
@@ -136,11 +140,11 @@ class LCA(object):
 
     @staticmethod
     def rank_assessment(l):
-        '''
+        """
         assesses rank [1:8] where 1 being cellular organism, 2 being domain... 8 being species
-        '''
+        """
         ni = 0
-        if l == None or l == [] or l == 'None':
+        if l is None or l == [] or l == 'None':  # Is the last condition necessary?
             return None
         else:
             for tax in l:
@@ -154,10 +158,10 @@ class LCA(object):
 
     @staticmethod
     def get_commons_from_mult_lists(l):
-        '''
+        """
         returns a list of common elements from multiple strings
-        '''
-        if not l == [] or l == None:
+        """
+        if l != [] or l is None:
             c = l[0]
             for num in range(1, (len(l))):
                 c = LCA.get_commons_from_2_list(c, l[num])
@@ -165,9 +169,9 @@ class LCA(object):
 
     @staticmethod
     def get_commons_from_2_list(l1, l2):
-        '''
+        """
         returns a list of common elements from two lists
-        '''
+        """
         result = []
         for element in l1:
             if element in l2:
@@ -175,37 +179,37 @@ class LCA(object):
         return result
 
 
-##RED functions and outputs
+# RED functions and outputs
 class RED(object):
 
     @staticmethod
     def apply_all(t):
-        '''applies RED to each node'''
+        """applies RED to each node"""
         t.add_features(red=0)
         for node in t.iter_descendants('preorder'):
             if not node.is_leaf():
                 RED.label_red(node)
-                #print(node, node.red)
+                # print(node, node.red)
             elif node.is_leaf():
                 node.add_features(red=1)
         return t
 
     @staticmethod
     def label_red(node):
-        '''labels RED to a single node given parent has RED value'''
+        """labels RED to a single node given parent has RED value"""
         return node.add_features(red=RED.get_red(node))
 
     @staticmethod
     def get_red(node):
-        '''gets the RED value associated with this node given parent has RED value'''
+        """gets the RED value associated with this node given parent has RED value"""
         red = node.up.red + (node.get_distance(node.up)/Dist.avg_dist_to_this_nodes_parent(node))*(1 - node.up.red)
         return red
 
     @staticmethod
     def avg_red(t, rank):
-        '''
+        """
         returns average red value for a rank
-        '''
+        """
         l = []
         for node in t.iter_descendants():
             if node.rank == rank:
@@ -215,14 +219,14 @@ class RED(object):
 
     @staticmethod
     def median_red(t, rank):
-        '''
+        """
         returns median red value for rank
-        '''
+        """
         l = []
         for node in t.iter_descendants():
             if node.rank == rank:
                 if node.red < 1:
-                    if not node.rank == None:
+                    if node.rank is not None:
                         l.append(node.red)
         if l == []:
             print(0)
@@ -230,19 +234,19 @@ class RED(object):
             return stat.median(l)
 
 
-#Adding lineages and ranks to internal nodes
+# Adding lineages and ranks to internal nodes
 class Map(object):
 
     @staticmethod
     def label_nodes(t):
-        '''
+        """
         label all node lineages based on rank level of filter
         and gives rank feature to all nodes
         note: nodes at level of filter only useful for distance measures
-        '''
+        """
         for node in t.traverse():
             try:
-                if not node.lineage == None:
+                if not node.lineage is None:
                     node.add_features(rank=LCA.rank_assessment(node.lineage))
                 else:
                     node.add_features(rank=None)
@@ -251,31 +255,31 @@ class Map(object):
 
     @staticmethod
     def class_all_nodes(t, **kwargs):
-        '''
+        """
         adds lineage feature to all nodes with available leaf descendants.
         LCA from leaf node info
-        '''
+        """
         kwargs_dict = kwargs
         LCA.assign_pass(t, kwargs_dict)
         Map.label_nodes(t)
         for node in reversed(list(t.traverse('levelorder'))):
-            if node.is_leaf() == False:
+            if node.is_leaf() is False:
                 new_lin = LCA.get_lca_lineage(node)
-                if new_lin == None:
+                if new_lin is None:
                     node.add_features(lineage=None)
                 else:
                     node.add_features(lineage=new_lin)
                     Map.label_nodes(t)
 
 
-##Graphing red vs rank
+# Graphing red vs rank
 def graph_red_vs_rank(t):
-    '''returns red vs rank graphic with median values at each rank and the correlation coefficient'''
+    """returns red vs rank graphic with median values at each rank and the correlation coefficient"""
     reds = []
     ranks = []
     for node in t.iter_descendants():
         if node.red < 1:
-            if not node.rank == None:
+            if node.rank is not None:
                 reds.append(node.red)
                 ranks.append(node.rank)
     plt.xlabel('RED')
@@ -283,8 +287,8 @@ def graph_red_vs_rank(t):
     plt.title('RED Assignment')
     plt.plot(reds, ranks, 'ro')
     plt.axis([0, 1, 1, 9])
-    for num in range(2,9):
-        if RED.median_red(t, num) == None:
+    for num in range(2, 9):
+        if RED.median_red(t, num) is None:
             continue
         else:
             median = RED.median_red(t, num)
@@ -297,7 +301,7 @@ def graph_red_vs_rank(t):
 
 
 parser = argparse.ArgumentParser(description='Calculate average distance of taxonomic rank of a tree to the root')
-parser.add_argument('-id', '--id_directory', type=str , metavar='', required=True, help='taxonomic IDs of a tree file')
+parser.add_argument('-id', '--id_directory', type=str, metavar='', required=True, help='taxonomic IDs of a tree file')
 parser.add_argument('-td', '--tree_directory', type=str, metavar='', required=True, help='tree file of interest')
 parser.add_argument('-rmeta', '--r_metagenome', type=int, metavar='', required=True, help='removed at given rank')
 parser.add_argument('-runc', '--r_unclassified', type=int, metavar='', required=True, help='removed at given rank')


### PR DESCRIPTION
Here I've made several changes to the format, interface, and lineage parsing.

I've adopted the PEP8 style for this code and made most or all changes to align with it.

The command-line interface (using argparse) has been modified such that many flags (boolean parameters) are not required and have instead been replaced with arguments. These two arguments can now determine the minimum ranks a lineage must contain to cotnribute to the RED summary with `--lineage_len` as well as the specific taxa we want to remove with `--remove`, though this second one hasn't been completely implemented yet.

Finally, the taxonomic lineages are filtered when they are read in, using TreeSAPP's utilities.clean_lineage_string, to remove group/cluster names and more. The `--lineage_len` depth doesn't count 'cellular organsims' as a rank. This functionality can be extended to other taxa.